### PR TITLE
Enable audio output over HDMI

### DIFF
--- a/EFI/OC/config_iMac20,2_iGPU_computing_only.plist
+++ b/EFI/OC/config_iMac20,2_iGPU_computing_only.plist
@@ -318,6 +318,8 @@
 				<string>onboard-1</string>
 				<key>layout-id</key>
 				<integer>28</integer>
+				<key>device-id</key>
+				<data>cKEAAA==</data>
 			</dict>
 		</dict>
 		<key>Delete</key>

--- a/EFI/OC/config_iMac20,2_iGPU_with_display_output.plist
+++ b/EFI/OC/config_iMac20,2_iGPU_with_display_output.plist
@@ -318,6 +318,8 @@
 				<string>onboard-1</string>
 				<key>layout-id</key>
 				<integer>28</integer>
+				<key>device-id</key>
+				<data>cKEAAA==</data>
 			</dict>
 		</dict>
 		<key>Delete</key>

--- a/EFI/OC/config_iMacPro1,1_no_iGPU_AMD_GPU_required.plist
+++ b/EFI/OC/config_iMacPro1,1_no_iGPU_AMD_GPU_required.plist
@@ -248,6 +248,8 @@
 				<string>onboard-1</string>
 				<key>layout-id</key>
 				<integer>28</integer>
+				<key>device-id</key>
+				<data>cKEAAA==</data>
 			</dict>
 		</dict>
 		<key>Delete</key>


### PR DESCRIPTION
This device-id is required for to enable audio over HDMI. Everything else is working correctly, all audio outputs including front headphone ports. Without this device-id, HDMI connected audio output monitors do not show in the audio output list:

![image](https://user-images.githubusercontent.com/5245272/104063236-c4777d00-51f3-11eb-9a17-a7c641816e0c.png)

It is required otherwise AppleHDAHDMI_DPDriver does not show up here also:

![Screenshot 2021-01-08 at 19 33 21](https://user-images.githubusercontent.com/5245272/104063262-cfcaa880-51f3-11eb-9aa2-d6b95ba17330.png)

Thanks
James 
